### PR TITLE
Improve tab icons

### DIFF
--- a/cmd/tangle-cli/main_test.go
+++ b/cmd/tangle-cli/main_test.go
@@ -49,9 +49,11 @@ func TestCli(t *testing.T) {
 		assert.FileExists(t, fmt.Sprintf("%s/%s", tempDir, "diff-test-test-1.yaml"))
 		assert.FileExists(t, fmt.Sprintf("%s/%s", tempDir, "diff-test-test-2.yaml"))
 		assert.FileExists(t, fmt.Sprintf("%s/%s", tempDir, "diff-prod-test-3.yaml"))
+		assert.FileExists(t, fmt.Sprintf("%s/%s", tempDir, "diff-prod-test-4.yaml"))
 		assert.FileExists(t, fmt.Sprintf("%s/%s", tempDir, "manifests-test-test-1.yaml"))
 		assert.FileExists(t, fmt.Sprintf("%s/%s", tempDir, "manifests-test-test-2.yaml"))
 		assert.FileExists(t, fmt.Sprintf("%s/%s", tempDir, "manifests-prod-test-3.yaml"))
+		assert.FileExists(t, fmt.Sprintf("%s/%s", tempDir, "manifests-prod-test-4.yaml"))
 		assert.FileExists(t, fmt.Sprintf("%s/%s", tempDir, "error-prod-test-3.txt"))
 
 		out, err := io.ReadAll(b)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -121,7 +121,7 @@ func TestGetApplications(t *testing.T) {
 			insecure:    true,
 			labels:      map[string]string{},
 			lengthTest:  2,
-			lengthProd:  1,
+			lengthProd:  2,
 			expectError: false,
 		},
 		{
@@ -220,7 +220,7 @@ func TestGetApplicationsWithRetries(t *testing.T) {
 					if result.Name == "test" {
 						assert.Len(t, result.Applications, 2)
 					} else if result.Name == "prod" {
-						assert.Len(t, result.Applications, 1)
+						assert.Len(t, result.Applications, 2)
 					}
 				}
 			} else {

--- a/web/src/lib/components/AppManifests.svelte
+++ b/web/src/lib/components/AppManifests.svelte
@@ -19,7 +19,7 @@
 		{diffData.errorResponse?.error}
 	</Alert>
 {:else if diffData.response.manifestGenerationError.length > 0}
-	<Card class="m-auto dark:bg-red-400" size="xl">
+	<Card class="m-auto dark:bg-red-400 mt-10" size="xl">
 		<Alert>
 			<div class="flex items-center gap-3">
 				<InfoCircleSolid class="w-5 h-5" />

--- a/web/src/routes/diffs/+page.svelte
+++ b/web/src/routes/diffs/+page.svelte
@@ -12,7 +12,7 @@
 		GradientButton
 	} from 'flowbite-svelte';
 
-	import { ExclamationCircleSolid, RefreshOutline } from 'flowbite-svelte-icons';
+	import { ExclamationCircleSolid, RefreshOutline, BellRingSolid } from 'flowbite-svelte-icons';
 
 	import { onMount } from 'svelte';
 	import { writable } from 'svelte/store';
@@ -125,8 +125,11 @@
 							<TabItem title={application.name} open={appIndex === 0}>
 								<div slot="title" class="flex items-center">
 									{#if application.syncStatus === 'Unknown' || $diffData[argoCDApplications.name]?.[application.name].error || $diffData[argoCDApplications.name]?.[application.name].response.manifestGenerationError.length > 0}<ExclamationCircleSolid
-											class="w-5 h-5 me-2 text-amber-500 dark:text-amber-400"
-										/>{/if}
+											class="w-5 h-5 me-2 text-rose-500 dark:text-rose-400"
+										/>
+									{:else if $diffData[argoCDApplications.name]?.[application.name].response.diffs.length > 0}
+										<BellRingSolid class="w-5 h-5 me-2 text-amber-500 dark:text-amber-400" />
+									{/if}
 									{application.name}
 								</div>
 								<Heading tag="h3">Status</Heading>

--- a/web/src/routes/diffs/+page.svelte
+++ b/web/src/routes/diffs/+page.svelte
@@ -125,7 +125,7 @@
 						{#each argoCDApplications.applications as application, appIndex (application.name)}
 							<TabItem title={application.name} open={appIndex === 0}>
 								<div slot="title" class="flex items-center">
-									{#if alertStatuses.includes(application.syncStatus) || application.health !== "Healthy" || $diffData[argoCDApplications.name]?.[application.name].error || $diffData[argoCDApplications.name]?.[application.name].response.manifestGenerationError.length > 0}<ExclamationCircleSolid
+									{#if alertStatuses.includes(application.syncStatus) || application.health !== 'Healthy' || $diffData[argoCDApplications.name]?.[application.name].error || $diffData[argoCDApplications.name]?.[application.name].response.manifestGenerationError.length > 0}<ExclamationCircleSolid
 											class="w-5 h-5 me-2 text-rose-500 dark:text-rose-400"
 										/>
 									{:else if $diffData[argoCDApplications.name]?.[application.name].response.diffs.length > 0}

--- a/web/src/routes/diffs/+page.svelte
+++ b/web/src/routes/diffs/+page.svelte
@@ -38,6 +38,7 @@
 
 	const diffData = writable<ApplicationsDiffsData>({});
 	let loaded: boolean = $state(false);
+	let alertStatuses: List[string] = ['OutOfSync', 'Unknown'];
 
 	onMount(() => {
 		client
@@ -124,7 +125,7 @@
 						{#each argoCDApplications.applications as application, appIndex (application.name)}
 							<TabItem title={application.name} open={appIndex === 0}>
 								<div slot="title" class="flex items-center">
-									{#if application.syncStatus === 'Unknown' || $diffData[argoCDApplications.name]?.[application.name].error || $diffData[argoCDApplications.name]?.[application.name].response.manifestGenerationError.length > 0}<ExclamationCircleSolid
+									{#if alertStatuses.includes(application.syncStatus) || application.health !== "Healthy" || $diffData[argoCDApplications.name]?.[application.name].error || $diffData[argoCDApplications.name]?.[application.name].response.manifestGenerationError.length > 0}<ExclamationCircleSolid
 											class="w-5 h-5 me-2 text-rose-500 dark:text-rose-400"
 										/>
 									{:else if $diffData[argoCDApplications.name]?.[application.name].response.diffs.length > 0}


### PR DESCRIPTION
- If diffs are found, show an icon on tab.
- If an application has an "unhealthy" status (out of sync, unhealthy), show a warning so end user will check.
- Don't overlap the reload button when showing manifest generation errors.